### PR TITLE
Update LessCSS Compiler to newest version (1.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>biz.gabrys.lesscss</groupId>
             <artifactId>compiler</artifactId>
-            <version>1.0</version>
+            <version>1.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bump to probably last version of this compiler.
Changelog: fixed quality flaws & correct creation of `includePaths` in CompilerOptionsBuilder
